### PR TITLE
Fix redirect_to issue

### DIFF
--- a/src/sign-in-with-google/README.txt
+++ b/src/sign-in-with-google/README.txt
@@ -3,7 +3,7 @@ Contributors: tarecord, chrismkindred
 Tags: Google, sign in, users, registration, register, Google Apps, G Suite, OAuth
 Requires at least: 4.8.1
 Tested up to: 5.0.3
-Stable tag: 1.2.0
+Stable tag: 1.2.1
 Requires PHP: 5.6
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -58,18 +58,19 @@ You will need to sign in to the [Google Developer Console](https://console.devel
 
 == Changelog ==
 
-= 1.2.0 =
-* Remove Google+ API
-* Remove call to css and js files that don't exist.
-* Add settings import and export
-* Update class and file naming
+= 1.2.1 =
+* Removed Google+ API Dependency
+* Removed call to css and js files that don't exist.
+* Added settings import and export
+* Updated class and file naming
+* Fixed bug where the user was not redirected properly after login.
 
 = 1.0.3 =
 * Fixed bug causing "Settings" link not to show on plugins page
 * Cleaned up error logs
 
 = 1.0.2 =
-* Rename plugin file to match directory
+* Renamed plugin file to match directory
 
 = 1.0.1 =
 * Fixed bug causing a redirect loop if using the button on the login page

--- a/src/sign-in-with-google/public/class-sign-in-with-google-public.php
+++ b/src/sign-in-with-google/public/class-sign-in-with-google-public.php
@@ -104,12 +104,15 @@ class Sign_In_With_Google_Public {
 	 */
 	public function add_signin_button() {
 
+		// Keep existing url query string intact.
+		$url = site_url( '?google_redirect&' ) . $_SERVER['QUERY_STRING'];
+
 		if ( get_option( 'siwg_show_on_login' ) ) {
 
 			ob_start();
 			?>
 				<div id="sign-in-with-google">
-					<a href="<?php echo site_url( '?google_redirect', 'http' ); ?>" title="Sign in with Google"><img src="<?php echo plugin_dir_url( __FILE__ ); ?>img/sign_in.svg"></a>
+					<a href="<?php echo $url; ?>" title="Sign in with Google"><img src="<?php echo plugin_dir_url( __FILE__ ); ?>img/sign_in.svg"></a>
 				</div>
 			<?php
 			echo ob_get_clean();

--- a/src/sign-in-with-google/sign-in-with-google.php
+++ b/src/sign-in-with-google/sign-in-with-google.php
@@ -15,7 +15,7 @@
  * Plugin Name:       Sign In With Google
  * Plugin URI:        http://www.northstarmarketing.com
  * Description:       Adds a "Sign in with Google" button to the login page, and allows users to sign up and login using Google.
- * Version:           1.2.0
+ * Version:           1.2.1
  * Author:            North Star Marketing
  * Author URI:        https://profiles.wordpress.org/northstarmarketing
  * License:           GPL-2.0+
@@ -67,7 +67,7 @@ require plugin_dir_path( __FILE__ ) . 'includes/class-sign-in-with-google.php';
  */
 function sign_in_with_google_run() {
 
-	$plugin = new Sign_In_With_Google( '1.2.0' );
+	$plugin = new Sign_In_With_Google( '1.2.1' );
 	$plugin->run();
 
 }


### PR DESCRIPTION
Since the user is directed over to Google for authentication, query parameters are lost, along with WordPress' `redirect_to` which sends the user to where they were trying to go before they were forced to the log in screen.

This fixes the issue by passing the query parameters over to Google as `state` which then get's sent back.

Closes #15 