### PR TITLE
Add WP-CLI Commands For Settings

### DIFF
--- a/src/sign-in-with-google/admin/class-sign-in-with-google-admin.php
+++ b/src/sign-in-with-google/admin/class-sign-in-with-google-admin.php
@@ -302,7 +302,7 @@ class Sign_In_With_Google_Admin {
 		// Strip all HTML and PHP tags and properly handle quoted strings.
 		$sanitized_input = strip_tags( stripslashes( $input ) );
 
-		if ( '' !== $sanitized_input && ! $this->verify_domain_list( $sanitized_input ) ) {
+		if ( '' !== $sanitized_input && ! Sign_In_With_Google_Utility::verify_domain_list( $sanitized_input ) ) {
 
 			add_settings_error(
 				'siwg_settings',
@@ -471,21 +471,6 @@ class Sign_In_With_Google_Admin {
 		wp_redirect( $redirect );
 		exit;
 
-	}
-
-	/**
-	 * Checks a string of comma separated domains to make sure they're in the correct format.
-	 *
-	 * @since    1.0.0
-	 * @param string $input A string of one or more comma dilimited domains.
-	 */
-	public function verify_domain_list( $input ) {
-
-		if ( preg_match( '~^\s*(?:(?:\w+(?:-+\w+)*\.)+[a-z]+)\s*(?:,\s*(?:(?:\w+(?:-+\w+)*\.)+[a-z]+)\s*)*$~', $input ) ) {
-			return true;
-		}
-
-		return false;
 	}
 
 	/**

--- a/src/sign-in-with-google/includes/class-sign-in-with-google-utility.php
+++ b/src/sign-in-with-google/includes/class-sign-in-with-google-utility.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * The file that contains general helpful methods.
+ *
+ * @link       http://www.northstarmarketing.com
+ * @since      1.2.2
+ *
+ * @package    Sign_In_With_Google
+ * @subpackage Sign_In_With_Google/includes
+ */
+
+/**
+ * A general helper class.
+ *
+ * @since      1.2.2
+ * @package    Sign_In_With_Google
+ * @subpackage Sign_In_With_Google/includes
+ * @author     Tanner Record <tanner.record@northstarmarketing.com>
+ */
+class Sign_In_With_Google_Utility {
+
+	/**
+	 * Checks a string of comma separated domains to make sure they're in the correct format.
+	 *
+	 * @since    1.0.0
+	 * @param string $input A string of one or more comma dilimited domains.
+	 */
+	public static function verify_domain_list( $input ) {
+
+		if ( preg_match( '~^\s*(?:(?:\w+(?:-+\w+)*\.)+[a-z]+)\s*(?:,\s*(?:(?:\w+(?:-+\w+)*\.)+[a-z]+)\s*)*$~', $input ) ) {
+			return true;
+		}
+
+		return false;
+	}
+
+}

--- a/src/sign-in-with-google/includes/class-sign-in-with-google-wpcli.php
+++ b/src/sign-in-with-google/includes/class-sign-in-with-google-wpcli.php
@@ -74,13 +74,31 @@ class Sign_In_With_Google_WPCLI {
 		$this->sanitize_args( $assoc_args );
 
 		// Verify the list of domains and update the setting.
-		if ( isset( $assoc_args['domains'] ) && Sign_In_With_Google_Utility::verify_domain_list( $assoc_args['domains'] ) ) {
-
-			update_option( 'siwg_google_domain_restriction', $assoc_args['domains'] );
-
+		if ( isset( $assoc_args['domains'] ) ) {
+			$this->update_domain_restriction( $assoc_args['domains'] );
 		}
 
-		WP_CLI::success( 'Settings updated: ' . print_r( $this->sanitize_args( $assoc_args ), true ) );
+		WP_CLI::success( 'Plugin settings updated' );
+
+	}
+
+	/**
+	 * Handles updating siwg_google_domain_restriction in the options table.
+	 *
+	 * @param string $domains The string of domains to verify and use.
+	 */
+	private function update_domain_restriction( $domains = '' ) {
+
+		if ( ! Sign_In_With_Google_Utility::verify_domain_list( $domains ) ) {
+			WP_CLI::error( 'Please use a valid list of domains' );
+		}
+
+		$result = update_option( 'siwg_google_domain_restriction', $domains );
+
+		if ( ! $result ) {
+			WP_CLI::warning( 'Not updating domain restriction - Input matches current setting' );
+		}
+
 	}
 
 	/**

--- a/src/sign-in-with-google/includes/class-sign-in-with-google-wpcli.php
+++ b/src/sign-in-with-google/includes/class-sign-in-with-google-wpcli.php
@@ -93,6 +93,11 @@ class Sign_In_With_Google_WPCLI {
 			$this->update_domain_restriction( $assoc_args['domains'] );
 		}
 
+		// Update the custom login parameter.
+		if ( isset( $assoc_args['custom_login_param'] ) ) {
+			$this->update_custom_login_param( $assoc_args['custom_login_param'] );
+		}
+
 		WP_CLI::success( 'Plugin settings updated' );
 
 	}
@@ -168,6 +173,19 @@ class Sign_In_With_Google_WPCLI {
 			WP_CLI::warning( 'Skipping Domain Restriction - Setting already matches' );
 		}
 
+	}
+
+	/**
+	 * Handles updating siwg_custom_login_param.
+	 *
+	 * @param string $param The string to use as the login parameter.
+	 */
+	private function update_custom_login_param( $param ) {
+		$result = update_option( 'siwg_custom_login_param', $param );
+
+		if ( ! $result ) {
+			WP_CLI::warning( 'Skipping Custom Login Parameter - Setting already matches' );
+		}
 	}
 
 	/**

--- a/src/sign-in-with-google/includes/class-sign-in-with-google-wpcli.php
+++ b/src/sign-in-with-google/includes/class-sign-in-with-google-wpcli.php
@@ -64,6 +64,11 @@ class Sign_In_With_Google_WPCLI {
 	 */
 	public function settings( $args = array(), $assoc_args = array() ) {
 
+		// Quit if no arguments are provided.
+		if ( empty( $assoc_args ) ) {
+			return;
+		}
+
 		// Sanitize everything.
 		$sanitized_args = $this->sanitize_args( $assoc_args );
 

--- a/src/sign-in-with-google/includes/class-sign-in-with-google-wpcli.php
+++ b/src/sign-in-with-google/includes/class-sign-in-with-google-wpcli.php
@@ -18,7 +18,7 @@
  */
 class Sign_In_With_Google_WPCLI {
 
-	/** phpcs:ignore
+	/**
 	 * Allows updating of Sign In With Google's settings
 	 *
 	 * ## OPTIONS
@@ -66,6 +66,9 @@ class Sign_In_With_Google_WPCLI {
 	 *     wp siwg settings --client_id=XXXXXX.apps.googleusercontent.com
 	 *
 	 * @when after_wp_load
+	 *
+	 * @param array $args       Array of values to update.
+	 * @param array $assoc_args An associative array of settings and values to update.
 	 */
 	public function settings( $args = array(), $assoc_args = array() ) {
 

--- a/src/sign-in-with-google/includes/class-sign-in-with-google-wpcli.php
+++ b/src/sign-in-with-google/includes/class-sign-in-with-google-wpcli.php
@@ -65,36 +65,11 @@ class Sign_In_With_Google_WPCLI {
 	public function settings( $args = array(), $assoc_args = array() ) {
 
 		// Sanitize everything.
-		$this->sanitize_args( $assoc_args );
+		$sanitized_args = $this->sanitize_args( $assoc_args );
 
-		// Update the Client ID.
-		if ( isset( $assoc_args['client_id'] ) ) {
-			$this->update_client_id( $assoc_args['client_id'] );
-		}
-
-		// Update the Client Secret.
-		if ( isset( $assoc_args['client_secret'] ) ) {
-			$this->update_client_secret( $assoc_args['client_secret'] );
-		}
-
-		// Update the default new user role.
-		if ( isset( $assoc_args['default_role'] ) ) {
-			$this->update_default_role( $assoc_args['default_role'] );
-		}
-
-		// Verify the list of domains and update the setting.
-		if ( isset( $assoc_args['domains'] ) ) {
-			$this->update_domain_restriction( $assoc_args['domains'] );
-		}
-
-		// Update the custom login parameter.
-		if ( isset( $assoc_args['custom_login_param'] ) ) {
-			$this->update_custom_login_param( $assoc_args['custom_login_param'] );
-		}
-
-		// Update show on login form.
-		if ( isset( $assoc_args['show_on_login'] ) ) {
-			$this->update_show_on_login_form( $assoc_args['show_on_login'] );
+		foreach ( $sanitized_args as $key => $value ) {
+			$method = 'update_' . $key;
+			$this->$method( $value );
 		}
 
 		WP_CLI::success( 'Plugin settings updated' );

--- a/src/sign-in-with-google/includes/class-sign-in-with-google-wpcli.php
+++ b/src/sign-in-with-google/includes/class-sign-in-with-google-wpcli.php
@@ -98,6 +98,11 @@ class Sign_In_With_Google_WPCLI {
 			$this->update_custom_login_param( $assoc_args['custom_login_param'] );
 		}
 
+		// Update show on login form.
+		if ( isset( $assoc_args['show_on_login'] ) ) {
+			$this->update_show_on_login_form( $assoc_args['show_on_login'] );
+		}
+
 		WP_CLI::success( 'Plugin settings updated' );
 
 	}
@@ -185,6 +190,19 @@ class Sign_In_With_Google_WPCLI {
 
 		if ( ! $result ) {
 			WP_CLI::warning( 'Skipping Custom Login Parameter - Setting already matches' );
+		}
+	}
+
+	/**
+	 * Handles updating siwg_show_on_login.
+	 *
+	 * @param bool $show Show the Sign In With Google button on the login form.
+	 */
+	private function update_show_on_login_form( $show = false ) {
+		$result = update_option( 'siwg_show_on_login', $show );
+
+		if ( ! $result ) {
+			WP_CLI::warning( 'Skipping Show On Login - Setting already matches' );
 		}
 	}
 

--- a/src/sign-in-with-google/includes/class-sign-in-with-google-wpcli.php
+++ b/src/sign-in-with-google/includes/class-sign-in-with-google-wpcli.php
@@ -32,7 +32,6 @@ class Sign_In_With_Google_WPCLI {
 	 * [--default_role=<role>]
 	 * : The role new users should have.
 	 * ---
-	 * default: subscriber
 	 * options:
 	 *   - subscriber
 	 *   - contributor
@@ -146,18 +145,21 @@ class Sign_In_With_Google_WPCLI {
 	 *
 	 * @param string $role The role applied for new users.
 	 */
-	private function update_default_role( $role = '' ) {
+	private function update_default_role( $role = 'subscriber' ) {
 		if ( '' == $role ) {
 			WP_CLI::error( 'Please enter a valid user role' );
 		}
 
-		// All role names are lowercase.
-		$role = strtolower( $role );
+		if ( 'subscriber' != $role ) {
 
-		$result = update_option( 'siwg_google_user_default_role', $role );
+			// All role names are lowercase.
+			$role = strtolower( $role );
 
-		if ( ! $result ) {
-			WP_CLI::warning( 'Skipping Default Role - Setting already matches' );
+			$result = update_option( 'siwg_google_user_default_role', $role );
+
+			if ( ! $result ) {
+				WP_CLI::warning( 'Skipping Default Role - Setting already matches' );
+			}
 		}
 	}
 

--- a/src/sign-in-with-google/includes/class-sign-in-with-google-wpcli.php
+++ b/src/sign-in-with-google/includes/class-sign-in-with-google-wpcli.php
@@ -59,7 +59,7 @@ class Sign_In_With_Google_WPCLI {
 	 *     https://www.example.com/my-custom-post?logmein // Log the user in and redirect to my-custom-post
 	 * ---
 	 *
-	 * [--show_on_login=<true|false>]
+	 * [--show_on_login=<1|0>]
 	 * : Show the "Sign In With Google" button on the login form.
 	 *
 	 * ## EXAMPLES
@@ -198,8 +198,8 @@ class Sign_In_With_Google_WPCLI {
 	 *
 	 * @param bool $show Show the Sign In With Google button on the login form.
 	 */
-	private function update_show_on_login_form( $show = false ) {
-		$result = update_option( 'siwg_show_on_login', $show );
+	private function update_show_on_login_form( $show = 0 ) {
+		$result = update_option( 'siwg_show_on_login', boolval( $show ) );
 
 		if ( ! $result ) {
 			WP_CLI::warning( 'Skipping Show On Login - Setting already matches' );

--- a/src/sign-in-with-google/includes/class-sign-in-with-google-wpcli.php
+++ b/src/sign-in-with-google/includes/class-sign-in-with-google-wpcli.php
@@ -73,6 +73,16 @@ class Sign_In_With_Google_WPCLI {
 		// Sanitize everything.
 		$this->sanitize_args( $assoc_args );
 
+		// Update the Client ID.
+		if ( isset( $assoc_args['client_id'] ) ) {
+			$this->update_client_id( $assoc_args['client_id'] );
+		}
+
+		// Update the Client Secret.
+		if ( isset( $assoc_args['client_secret'] ) ) {
+			$this->update_client_secret( $assoc_args['client_secret'] );
+		}
+
 		// Verify the list of domains and update the setting.
 		if ( isset( $assoc_args['domains'] ) ) {
 			$this->update_domain_restriction( $assoc_args['domains'] );
@@ -80,6 +90,40 @@ class Sign_In_With_Google_WPCLI {
 
 		WP_CLI::success( 'Plugin settings updated' );
 
+	}
+
+	/**
+	 * Handles updating siwg_google_client_id.
+	 *
+	 * @param string $client_id The ID to use with Google's Oauth.
+	 */
+	private function update_client_id( $client_id = '' ) {
+		if ( '' == $client_id ) {
+			WP_CLI::error( 'Please enter a valid Client ID' );
+		}
+
+		$result = update_option( 'siwg_google_client_id', $client_id );
+
+		if ( ! $result ) {
+			WP_CLI::warning( 'Skipping Client ID - Setting already matches' );
+		}
+	}
+
+	/**
+	 * Handles updating siwg_google_client_secret.
+	 *
+	 * @param string $client_secret The secret to use with Google's Oauth.
+	 */
+	private function update_client_secret( $client_secret = '' ) {
+		if ( '' == $client_secret ) {
+			WP_CLI::error( 'Please enter a valid Client Secret' );
+		}
+
+		$result = update_option( 'siwg_google_client_secret', $client_secret );
+
+		if ( ! $result ) {
+			WP_CLI::warning( 'Skipping Client Secret - Setting already matches' );
+		}
 	}
 
 	/**

--- a/src/sign-in-with-google/includes/class-sign-in-with-google-wpcli.php
+++ b/src/sign-in-with-google/includes/class-sign-in-with-google-wpcli.php
@@ -31,14 +31,6 @@ class Sign_In_With_Google_WPCLI {
 	 *
 	 * [--default_role=<role>]
 	 * : The role new users should have.
-	 * ---
-	 * options:
-	 *   - subscriber
-	 *   - contributor
-	 *   - author
-	 *   - editor
-	 *   - administrator
-	 * ---
 	 *
 	 * [--domains=<domains>]
 	 * : A comma separated list of domains to restrict new users to.
@@ -157,6 +149,13 @@ class Sign_In_With_Google_WPCLI {
 
 			// All role names are lowercase.
 			$role = strtolower( $role );
+
+			// Get a list of all the existing roles.
+			$existing_roles = array_keys( get_editable_roles() );
+
+			if ( ! in_array( $role, $existing_roles ) ) {
+				WP_CLI::error( 'Role does not exist.' );
+			}
 
 			$result = update_option( 'siwg_google_user_default_role', $role );
 

--- a/src/sign-in-with-google/includes/class-sign-in-with-google-wpcli.php
+++ b/src/sign-in-with-google/includes/class-sign-in-with-google-wpcli.php
@@ -140,7 +140,7 @@ class Sign_In_With_Google_WPCLI {
 		$result = update_option( 'siwg_google_domain_restriction', $domains );
 
 		if ( ! $result ) {
-			WP_CLI::warning( 'Not updating domain restriction - Input matches current setting' );
+			WP_CLI::warning( 'Skipping Domain Restriction - Setting already matches' );
 		}
 
 	}

--- a/src/sign-in-with-google/includes/class-sign-in-with-google-wpcli.php
+++ b/src/sign-in-with-google/includes/class-sign-in-with-google-wpcli.php
@@ -83,6 +83,11 @@ class Sign_In_With_Google_WPCLI {
 			$this->update_client_secret( $assoc_args['client_secret'] );
 		}
 
+		// Update the default new user role.
+		if ( isset( $assoc_args['default_role'] ) ) {
+			$this->update_default_role( $assoc_args['default_role'] );
+		}
+
 		// Verify the list of domains and update the setting.
 		if ( isset( $assoc_args['domains'] ) ) {
 			$this->update_domain_restriction( $assoc_args['domains'] );
@@ -123,6 +128,26 @@ class Sign_In_With_Google_WPCLI {
 
 		if ( ! $result ) {
 			WP_CLI::warning( 'Skipping Client Secret - Setting already matches' );
+		}
+	}
+
+	/**
+	 * Handles updating siwg_google_user_default_role.
+	 *
+	 * @param string $role The role applied for new users.
+	 */
+	private function update_default_role( $role = '' ) {
+		if ( '' == $role ) {
+			WP_CLI::error( 'Please enter a valid user role' );
+		}
+
+		// All role names are lowercase.
+		$role = strtolower( $role );
+
+		$result = update_option( 'siwg_google_user_default_role', $role );
+
+		if ( ! $result ) {
+			WP_CLI::warning( 'Skipping Default Role - Setting already matches' );
 		}
 	}
 

--- a/src/sign-in-with-google/includes/class-sign-in-with-google-wpcli.php
+++ b/src/sign-in-with-google/includes/class-sign-in-with-google-wpcli.php
@@ -1,0 +1,109 @@
+<?php
+/**
+ * Register all wpcli commands for the plugin.
+ *
+ * @link       http://www.northstarmarketing.com
+ * @since      1.2.2
+ *
+ * @package    Sign_In_With_Google
+ * @subpackage Sign_In_With_Google/includes
+ */
+
+/**
+ * Register all wpcli commands for the plugin.
+ *
+ * @package    Sign_In_With_Google
+ * @subpackage Sign_In_With_Google/includes
+ * @author     Tanner Record <tanner.record@northstarmarketing.com>
+ */
+class Sign_In_With_Google_WPCLI {
+
+	/** phpcs:ignore
+	 * Allows updating of Sign In With Google's settings
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--client_id=<client_id>]
+	 * : Your Oauth Client ID from console.developers.google.com
+	 *
+	 * [--client_secret=<client_secret>]
+	 * : Your Oauth Client Secret from console.developers.google.com
+	 *
+	 * [--default_role=<role>]
+	 * : The role new users should have.
+	 * ---
+	 * default: subscriber
+	 * options:
+	 *   - subscriber
+	 *   - contributor
+	 *   - author
+	 *   - editor
+	 *   - administrator
+	 * ---
+	 *
+	 * [--domains=<domains>]
+	 * : A comma separated list of domains to restrict new users to.
+	 * ---
+	 * example:
+	 *     wp siwg settings --domains=google.com,example.net,other.org
+	 * ---
+	 *
+	 * [--custom_login_param=<parameter>]
+	 * : The custom login parameter to be used.
+	 * ---
+	 * example:
+	 *     wp siwg settings --custom_login_param=logmein
+	 * ---
+	 * URL to log in:
+	 *     https://www.example.com?logmein // Send the user to authenticate with Google and log in
+	 *     https://www.example.com/my-custom-post?logmein // Log the user in and redirect to my-custom-post
+	 * ---
+	 *
+	 * [--show_on_login=<true|false>]
+	 * : Show the "Sign In With Google" button on the login form.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp siwg settings --client_id=XXXXXX.apps.googleusercontent.com
+	 *
+	 * @when after_wp_load
+	 */
+	public function settings( $args = array(), $assoc_args = array() ) {
+
+		// Sanitize everything.
+		$this->sanitize_args( $assoc_args );
+
+		// Verify the list of domains and update the setting.
+		if ( isset( $assoc_args['domains'] ) && Sign_In_With_Google_Utility::verify_domain_list( $assoc_args['domains'] ) ) {
+
+			update_option( 'siwg_google_domain_restriction', $assoc_args['domains'] );
+
+		}
+
+		WP_CLI::success( 'Settings updated: ' . print_r( $this->sanitize_args( $assoc_args ), true ) );
+	}
+
+	/**
+	 * Sanitize command arguments
+	 *
+	 * @since 1.2.2
+	 *
+	 * @param array $args An array of arguments to sanitize.
+	 */
+	private function sanitize_args( $args = array() ) {
+		$sanitized_assoc_args = array();
+
+		// Just return if $args is empty.
+		if ( empty( $args ) ) {
+			return;
+		}
+
+		foreach ( $args as $key => $value ) {
+			$sanitized_assoc_args[ $key ] = sanitize_text_field( $value );
+		}
+
+		return $sanitized_assoc_args;
+	}
+
+
+}

--- a/src/sign-in-with-google/includes/class-sign-in-with-google-wpcli.php
+++ b/src/sign-in-with-google/includes/class-sign-in-with-google-wpcli.php
@@ -150,7 +150,7 @@ class Sign_In_With_Google_WPCLI {
 	 *
 	 * @param string $domains The string of domains to verify and use.
 	 */
-	private function update_domain_restriction( $domains = '' ) {
+	private function update_domains( $domains = '' ) {
 
 		if ( ! Sign_In_With_Google_Utility::verify_domain_list( $domains ) ) {
 			WP_CLI::error( 'Please use a valid list of domains' );
@@ -182,7 +182,7 @@ class Sign_In_With_Google_WPCLI {
 	 *
 	 * @param bool $show Show the Sign In With Google button on the login form.
 	 */
-	private function update_show_on_login_form( $show = 0 ) {
+	private function update_show_on_login( $show = 0 ) {
 		$result = update_option( 'siwg_show_on_login', boolval( $show ) );
 
 		if ( ! $result ) {

--- a/src/sign-in-with-google/includes/class-sign-in-with-google.php
+++ b/src/sign-in-with-google/includes/class-sign-in-with-google.php
@@ -110,6 +110,11 @@ class Sign_In_With_Google {
 		require_once plugin_dir_path( dirname( __FILE__ ) ) . 'includes/class-sign-in-with-google-i18n.php';
 
 		/**
+		 * A helpful ultility class.
+		 */
+		require_once plugin_dir_path( dirname( __FILE__ ) ) . 'includes/class-sign-in-with-google-utility.php';
+
+		/**
 		 * The class responsible for defining all actions that occur in the admin area.
 		 */
 		require_once plugin_dir_path( dirname( __FILE__ ) ) . 'admin/class-sign-in-with-google-admin.php';

--- a/src/sign-in-with-google/includes/class-sign-in-with-google.php
+++ b/src/sign-in-with-google/includes/class-sign-in-with-google.php
@@ -77,6 +77,10 @@ class Sign_In_With_Google {
 		$this->define_admin_hooks();
 		$this->define_public_hooks();
 
+		// If WordPress is running in WP_CLI.
+		if ( defined( 'WP_CLI' ) && WP_CLI ) {
+			$this->register_cli_commands();
+		}
 	}
 
 	/**
@@ -108,6 +112,11 @@ class Sign_In_With_Google {
 		 * of the plugin.
 		 */
 		require_once plugin_dir_path( dirname( __FILE__ ) ) . 'includes/class-sign-in-with-google-i18n.php';
+
+		/**
+		 * The class responsible for registering custom CLI commands.
+		 */
+		require_once plugin_dir_path( dirname( __FILE__ ) ) . 'includes/class-sign-in-with-google-wpcli.php';
 
 		/**
 		 * A helpful ultility class.
@@ -199,6 +208,20 @@ class Sign_In_With_Google {
 		$this->loader->add_action( 'login_enqueue_scripts', $plugin_public, 'enqueue_styles' );
 		$this->loader->add_action( 'login_enqueue_scripts', $plugin_public, 'enqueue_scripts' );
 		$this->loader->add_action( 'login_form', $plugin_public, 'add_signin_button' );
+
+	}
+
+	/**
+	 * Register the WP_CLI commands.
+	 *
+	 * @since  1.2.0
+	 * @access private
+	 */
+	private function register_cli_commands() {
+
+		$plugin_cli = new Sign_In_With_Google_WPCLI();
+
+		WP_CLI::add_command( 'siwg', $plugin_cli );
 
 	}
 

--- a/tests/test-utility.php
+++ b/tests/test-utility.php
@@ -11,28 +11,6 @@
 class UtilityTest extends WP_UnitTestCase {
 
 	/**
-	 * The name of the plugin.
-	 *
-	 * @var string
-	 */
-	private $plugin_name;
-
-	/**
-	 * The version of the plugin.
-	 *
-	 * @var string
-	 */
-	private $plugin_version;
-
-	/**
-	 * Sets up the $plugin_name and $plugin_version required by Google_Sign_Up_Admin.
-	 */
-	function setUp() {
-		$this->plugin_name = 'sign-in-with-google';
-		$this->version     = '1.0.0';
-	}
-
-	/**
 	 * Tests the domain input validation. Users must provide a correct domain or comma
 	 * delimited string of domains.
 	 *

--- a/tests/test-utility.php
+++ b/tests/test-utility.php
@@ -1,14 +1,14 @@
 <?php
 /**
- * Class AdminTest
+ * Class UtilityTest
  *
  * @package Sign_In_With_Google
  */
 
 /**
- * Admin test case.
+ * Utility test case.
  */
-class AdminTest extends WP_UnitTestCase {
+class UtilityTest extends WP_UnitTestCase {
 
 	/**
 	 * The name of the plugin.
@@ -35,23 +35,28 @@ class AdminTest extends WP_UnitTestCase {
 	/**
 	 * Tests the domain input validation. Users must provide a correct domain or comma
 	 * delimited string of domains.
-	 * 
+	 *
 	 * @dataProvider domain_test_array
+	 *
+	 * @param string $input    The domain list to validate.
+	 * @param bool   $expected The result of validation.
 	 */
-	function test_verify_domain_list($input, $expected) {
-		$sign_in_with_google_admin = new Sign_In_With_Google_Admin( $this->plugin_name, $this->version );
-		$result = $sign_in_with_google_admin->verify_domain_list( $input );
+	function test_verify_domain_list( $input, $expected ) {
+		$result = Sign_In_With_Google_Utility::verify_domain_list( $input );
 		$this->assertEquals( $result, $expected );
 	}
 
+	/**
+	 * Provides an array of data to check domain validation.
+	 */
 	function domain_test_array() {
 		return [
-			['thisisatest.com', true],
-			['thisisatest.com, another.com', true],
-			['test.com, another.com, a.com, 1.com', true],
-			['t.com, 1.com, 2.com, 3', false],
-			['test.com, another, test.com', false],
-			['somedomain, another', false],
+			[ 'thisisatest.com', true ],
+			[ 'thisisatest.com, another.com', true ],
+			[ 'test.com, another.com, a.com, 1.com', true ],
+			[ 't.com, 1.com, 2.com, 3', false ],
+			[ 'test.com, another, test.com', false ],
+			[ 'somedomain, another', false ],
 		];
 	}
 }


### PR DESCRIPTION
I've added some CLI commands so it's easier to install and configure the plugin on multiple sites.

```
usage: wp siwg settings [--client_id=<client_id>] [--client_secret=<client_secret>] [--default_role=<role>] [--domains=<domains>] [--custom_login_param=<parameter>] [--show_on_login=<1|0>]
```