### PR TITLE
Fix domain verification bug

### DIFF
--- a/src/sign-in-with-google/admin/class-sign-in-with-google-admin.php
+++ b/src/sign-in-with-google/admin/class-sign-in-with-google-admin.php
@@ -797,7 +797,7 @@ class Sign_In_With_Google_Admin {
 		$domains     = array_filter( explode( ', ', get_option( 'siwg_google_domain_restriction' ) ) );
 		$user_domain = explode( '@', $this->user->email );
 
-		if ( ! empty( $domains ) && ! in_array( $user_domain[1], $domains ) ) {
+		if ( ! empty( $domains ) && ! in_array( $user_domain[1], $domains, true ) ) {
 			wp_redirect( wp_login_url() . '?google_login=incorrect_domain' );
 			exit;
 		}

--- a/src/sign-in-with-google/admin/class-sign-in-with-google-admin.php
+++ b/src/sign-in-with-google/admin/class-sign-in-with-google-admin.php
@@ -794,7 +794,7 @@ class Sign_In_With_Google_Admin {
 	 */
 	protected function check_domain_restriction() {
 		// The user doesn't have the correct domain, don't authenticate them.
-		$domains     = explode( ', ', get_option( 'siwg_google_domain_restriction' ) );
+		$domains     = array_filter( explode( ', ', get_option( 'siwg_google_domain_restriction' ) ) );
 		$user_domain = explode( '@', $this->user->email );
 
 		if ( ! empty( $domains ) && ! in_array( $user_domain[1], $domains ) ) {


### PR DESCRIPTION
From 1st issue in https://wordpress.org/support/topic/some-errors-22/

"There definitely needs to have added array_filter because otherwise, even empty string exploded by comma, it makes the next step return TRUE (because $domains[0] member exists, even though that member has empty value). So, array_filter will fix that. Otherwise, we are returned back to our site after G-login, and still shown the wp-login screen (with appended URL:
`/?google_login=incorrect_domain` ), because of that line."