### PR TITLE
Add link to plugin page for more detailed instruction

### DIFF
--- a/src/sign-in-with-google/admin/class-sign-in-with-google-admin.php
+++ b/src/sign-in-with-google/admin/class-sign-in-with-google-admin.php
@@ -232,7 +232,12 @@ class Sign_In_With_Google_Admin {
 	 * @since    1.0.0
 	 */
 	public function siwg_section() {
-		echo '<p>' . __( 'Please paste in the necessary credentials so that we can authenticate your users.', 'sign-in-with-google' ) . '</p>';
+		echo sprintf(
+			'<p>%s <a href="%s" rel="noopener" target="_blank">%s</a></p>',
+			__( 'Please paste in the necessary credentials so that we can authenticate your users.', 'sign-in-with-google' ),
+			'https://wordpress.org/plugins/sign-in-with-google/#where%20can%20i%20get%20a%20client%20id%20and%20client%20secret%3F',
+			__( 'Learn More', 'sign-in-with-google' )
+		);
 	}
 
 	/**


### PR DESCRIPTION
When users are setting up the plugin, it makes sense to help point them in the right direction.