### PR TITLE
Add method for sanitizing email addresses

### DIFF
--- a/src/sign-in-with-google/includes/class-sign-in-with-google-utility.php
+++ b/src/sign-in-with-google/includes/class-sign-in-with-google-utility.php
@@ -34,4 +34,18 @@ class Sign_In_With_Google_Utility {
 		return false;
 	}
 
+	/**
+	 * Remove `.` and `+` from gmail to avoid abuse and manipulations
+	 *	 (i.e. `jos.hu.a+is.cheating.32@gmail.com`—`joshua@gmail.com`)
+	 *
+	 * @see https://stackoverflow.com/a/41313340/2377343
+	 * @since 1.5.2
+	 * @param object $user_mail  The Google email address.
+	 */
+	public static function sanitize_google_email( $user_mail ) {
+
+		$sanitized_email = preg_replace( '/\+.*\@/s', '@', $user_mail );
+
+		return $sanitized_email;
+	}
 }

--- a/tests/test-utility.php
+++ b/tests/test-utility.php
@@ -37,4 +37,31 @@ class UtilityTest extends WP_UnitTestCase {
 			[ 'somedomain, another', false ],
 		];
 	}
+
+	/**
+	 * Tests the sanitization of google email addresses.
+	 *
+	 * @dataProvider sanitize_google_email_data
+	 *
+	 * @param string $input    The unsanitized email.
+	 * @param string $expected The expected sanitized email.
+	 */
+	function test_sanitize_google_email( $input, $expected ) {
+		$result = Sign_In_With_Google_Utility::sanitize_google_email( $input );
+		$this->assertEquals( $result, $expected );
+	}
+
+	/**
+	 * Provides an array of data to check domain validation.
+	 */
+	function sanitize_google_email_data() {
+		return [
+			[ 'first+spam@gmail.com', 'first@gmail.com' ],
+			[ 'first+123@gmail.com', 'first@gmail.com' ],
+			[ 'first+@gmail.com', 'first@gmail.com' ],
+			[ 'first+last@gmail.com', 'first@gmail.com' ],
+			[ 'first.last@gmail.com', 'first.last@gmail.com' ],
+			[ 'first.last+test@gmail.com', 'first.last@gmail.com' ],
+		];
+	}
 }


### PR DESCRIPTION
Google allows users to append `+` to their emails as a simple alias (first.last+spam-email@domain.com). So we should sanitize these types of emails before comparing them with existing email addresses.