### PR TITLE
Disallow registrations if disabled in settings

### DIFF
--- a/src/sign-in-with-google/admin/class-sign-in-with-google-admin.php
+++ b/src/sign-in-with-google/admin/class-sign-in-with-google-admin.php
@@ -733,6 +733,12 @@ class Sign_In_With_Google_Admin {
 
 		$user = get_user_by( 'email', $user_data->email );
 
+		// Redirect the user if registrations are disabled.
+		if ( false === $user && ! get_option( 'users_can_register' ) ) {
+			wp_redirect( site_url( 'wp-login.php?registration=disabled' ) );
+			exit;
+		}
+
 		if ( false !== $user ) {
 			update_user_meta( $user->ID, 'first_name', $user_data->given_name );
 			update_user_meta( $user->ID, 'last_name', $user_data->family_name );


### PR DESCRIPTION
If the user unchecks the "Anyone Can Register" field in the Settings then redirect new users back to the "Registrations are disabled" error message on the login form.

closes #55 

<img src="https://user-images.githubusercontent.com/6947218/94809244-4e77a480-03c0-11eb-8c7b-f31b3aaea86d.png" width="500">
