### PR TITLE
Sets the client secret input HTML tag as password to hide in the form

### DIFF
--- a/src/sign-in-with-google/admin/class-sign-in-with-google-admin.php
+++ b/src/sign-in-with-google/admin/class-sign-in-with-google-admin.php
@@ -265,7 +265,7 @@ class Sign_In_With_Google_Admin {
 	 * @since    1.0.0
 	 */
 	public function siwg_google_client_secret() {
-		echo '<input name="siwg_google_client_secret" id="siwg_google_client_secret" type="text" size="50" value="' . get_option( 'siwg_google_client_secret' ) . '"/>';
+		echo '<input name="siwg_google_client_secret" id="siwg_google_client_secret" type="password" size="50" value="' . get_option( 'siwg_google_client_secret' ) . '"/>';
 	}
 
 	/**


### PR DESCRIPTION
The Client Secret is not currently hidden in the Admin page form.  Setting it to type of password will hide the secret from view.